### PR TITLE
Allow customising sounds for specific event types

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,8 +66,8 @@ A nix-darwin module is available for managing yknotify-rs as a macOS LaunchAgent
           {
             services.yknotify-rs = {
               enable = true;
-              
-              # You can set notification sounds (find available sounds in /System/Library/Sounds):
+
+              # You can set notification sounds (find available sounds in `/System/Library/Sounds`):
               requestSound = "Purr";
               dismissedSound = "Pop";
             };
@@ -168,11 +168,11 @@ Options:
 
 Example output:
 
-```json
-{"ts":"2025-02-12T20:09:03Z","type":"FIDO2"}
-{"ts":"2025-02-12T20:09:14Z","type":"OpenPGP"}
 ```
-
+2025-07-19T16:57:42.475000Z  INFO yknotify_rs: listening for events
+2025-07-19T16:57:53.343860Z  INFO yknotify_rs: dispatching notification for touch event kind=FIDO2 event=start
+2025-07-19T16:57:54.949215Z  INFO yknotify_rs: dispatching notification for touch event kind=FIDO2 event=stop
+```
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,13 @@ A nix-darwin module is available for managing yknotify-rs as a macOS LaunchAgent
         modules = [
           yknotify-rs.darwinModules.default
           {
-            services.yknotify-rs.enable = true;
+            services.yknotify-rs = {
+              enable = true;
+              
+              # You can set notification sounds (find available sounds in /System/Library/Sounds):
+              requestSound = "Purr";
+              dismissedSound = "Pop";
+            };
           }
         ];
       };
@@ -103,8 +109,61 @@ mv target/release/yknotify-rs /usr/local/bin/
 
 ## Usage
 
-```sh
-yknotify-rs
+```
+Usage: yknotify-rs [OPTIONS]
+
+Options:
+      --request-sound <REQUEST_SOUND>
+          Name of the macOS system sound to play when a new touch request is detected.
+
+          Available sounds can be found in `/System/Library/Sounds`, `/Library/Sounds` or
+          `~/Library/Sounds`. The sound name must be a filename without an extension, e.g. `Purr`.
+
+          [env: YKNOTIFY_REQUEST_SOUND=]
+
+      --fido2-request-sound <FIDO2_REQUEST_SOUND>
+          Name of the macOS system sound to play when a new FIDO2 touch request is detected.
+
+          Overrides the `--request-sound` option, which sets the request sound for all types of
+          touch request.
+
+          [env: YKNOTIFY_FIDO2_REQUEST_SOUND=]
+
+      --openpgp-request-sound <OPENPGP_REQUEST_SOUND>
+          Name of the macOS system sound to play when a new OpenPGP touch request is detected.
+
+          Overrides the `--request-sound` option, which sets the request sound for all types of
+          touch request.
+
+          [env: YKNOTIFY_OPENPGP_REQUEST_SOUND=]
+
+      --dismissed-sound <DISMISSED_SOUND>
+          Name of the macOS system sound to play when a touch request is dismissed (for example,
+          when the YubiKey is touched).
+
+          Available sounds can be found in `/System/Library/Sounds`, `/Library/Sounds` or
+          `~/Library/Sounds`. The sound name must be a filename without an extension, e.g. `Pop`.
+
+          [env: YKNOTIFY_DISMISSED_SOUND=]
+
+      --fido2-dismissed-sound <FIDO2_DISMISSED_SOUND>
+          Name of the macOS system sound to play when a FIDO2 touch request is dismissed.
+
+          Overrides the `--dismissed-sound` option, which sets the dismissed sound for all types of
+          touch request.
+
+          [env: YKNOTIFY_FIDO2_DISMISSED_SOUND=]
+
+      --openpgp-dismissed-sound <OPENPGP_DISMISSED_SOUND>
+          Name of the macOS system sound to play when an OpenPGP touch request is dismissed.
+
+          Overrides the `--dismissed-sound` option, which sets the dismissed sound for all types of
+          touch request.
+
+          [env: YKNOTIFY_OPENPGP_DISMISSED_SOUND=]
+
+  -h, --help
+          Print help (see a summary with '-h')
 ```
 
 Example output:

--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
               requestSound = lib.mkOption {
                 description = ''
                   Name of the macOS system sound to play when a new touch request is detected.
-                  
+
                   Available sounds can be found in `/System/Library/Sounds`, `/Library/Sounds` or
                   `~/Library/Sounds`. The sound name must be a filename without an extension, e.g.
                   `Purr`.
@@ -68,13 +68,58 @@
                 default = null;
               };
 
+              fido2RequestSound = lib.mkOption {
+                description = ''
+                  Name of the macOS system sound to play when a new FIDO2 touch request is detected.
+
+                  Overrides the `requestSound` option, which sets the request sound for all types of
+                  touch request.
+                '';
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+              };
+
+              openPGPRequestSound = lib.mkOption {
+                description = ''
+                  Name of the macOS system sound to play when a new OpenPGP touch request is
+                  detected.
+
+                  Overrides the `requestSound` option, which sets the request sound for all types of
+                  touch request.
+                '';
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+              };
+
               dismissedSound = lib.mkOption {
                 description = ''
                   Name of the macOS system sound to play when a new touch request is detected.
-                  
+
                   Available sounds can be found in `/System/Library/Sounds`, `/Library/Sounds` or
                   `~/Library/Sounds`. The sound name must be a filename without an extension, e.g.
                   `Pop`.
+                '';
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+              };
+
+              fido2DismissedSound = lib.mkOption {
+                description = ''
+                  Name of the macOS system sound to play when a FIDO2 touch request is dismissed.
+
+                  Overrides the `dismissedSound` option, which sets the dismissed sound for all
+                  types of touch request.
+                '';
+                type = lib.types.nullOr lib.types.str;
+                default = null;
+              };
+
+              openPGPDismissedSound = lib.mkOption {
+                description = ''
+                  Name of the macOS system sound to play when an OpenPGP touch request is dismissed.
+
+                  Overrides the `dismissedSound` option, which sets the dismissed sound for all
+                  types of touch request.
                 '';
                 type = lib.types.nullOr lib.types.str;
                 default = null;
@@ -96,12 +141,66 @@
                     # StandardErrorPath = "/var/log/${Label}/stderr.log";
                   };
                   environment = {
-                    YKNOTIFY_REQUEST_SOUND = lib.mkIf (cfg.requestSound != null)
+                    YKNOTIFY_REQUEST_SOUND = lib.mkIf
+                      (cfg.requestSound != null)
                       cfg.requestSound;
-                    YKNOTIFY_DISMISSED_SOUND = lib.mkIf (cfg.dismissedSound != null)
+
+                    YKNOTIFY_FIDO2_REQUEST_SOUND = lib.mkIf
+                      (cfg.fido2RequestSound != null)
+                      cfg.fido2RequestSound;
+
+                    YKNOTIFY_OPENPGP_REQUEST_SOUND = lib.mkIf
+                      (cfg.openPGPRequestSound != null)
+                      cfg.openPGPRequestSound;
+
+                    YKNOTIFY_DISMISSED_SOUND = lib.mkIf
+                      (cfg.dismissedSound != null)
                       cfg.dismissedSound;
+
+                    YKNOTIFY_FIDO2_DISMISSED_SOUND = lib.mkIf
+                      (cfg.fido2DismissedSound != null)
+                      cfg.fido2DismissedSound;
+
+                    YKNOTIFY_OPENPGP_DISMISSED_SOUND = lib.mkIf
+                      (cfg.openPGPDismissedSound != null)
+                      cfg.openPGPDismissedSound;
                   };
                 };
+
+                assertions = [
+                  {
+                    assertion = cfg.fido2RequestSound != null -> cfg.requestSound == null;
+                    message = ''
+                      fido2RequestSound cannot be set at the same time as requestSound. Either set
+                      the request sound individually for each type of request, or use requestSound
+                      to set a single sound for all requests.
+                    '';
+                  }
+                  {
+                    assertion = cfg.openPGPRequestSound != null -> cfg.requestSound == null;
+                    message = ''
+                      openPGPRequestSound cannot be set at the same time as requestSound. Either set
+                      the request sound individually for each type of request, or use requestSound
+                      to set a single sound for all requests.
+                    '';
+                  }
+                  {
+                    assertion = cfg.fido2DismissedSound != null -> cfg.dismissedSound == null;
+                    message = ''
+                      fido2DismissedSound cannot be set at the same time as dismissedSound. Either
+                      set the dismissed sound individually for each type of request, or use
+                      dismissedSound to set a single sound for all requests.
+                    '';
+                  }
+                  {
+                    assertion = cfg.openPGPDismissedSound != null -> cfg.requestSound == null;
+                    message = ''
+                      openPGPDismissedSound cannot be set at the same time as dismissedSound. Either
+                      set the dismissed sound individually for each type of request, or use
+                      dismissedSound to set a single sound for all requests.
+                    '';
+                  }
+                ];
               };
           };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,28 @@ struct Args {
     #[arg(long, env = "YKNOTIFY_REQUEST_SOUND")]
     request_sound: Option<String>,
 
+    /// Name of the macOS system sound to play when a new FIDO2 touch request is detected.
+    ///
+    /// Overrides the `--request-sound` option, which sets the request sound for all types of touch
+    /// request.
+    #[arg(
+        long,
+        conflicts_with = "request_sound",
+        env = "YKNOTIFY_FIDO2_REQUEST_SOUND"
+    )]
+    fido2_request_sound: Option<String>,
+
+    /// Name of the macOS system sound to play when a new OpenPGP touch request is detected.
+    ///
+    /// Overrides the `--request-sound` option, which sets the request sound for all types of touch
+    /// request.
+    #[arg(
+        long,
+        conflicts_with = "request_sound",
+        env = "YKNOTIFY_OPENPGP_REQUEST_SOUND"
+    )]
+    openpgp_request_sound: Option<String>,
+
     /// Name of the macOS system sound to play when a touch request is dismissed (for example, when
     /// the YubiKey is touched).
     ///
@@ -27,6 +49,28 @@ struct Args {
     /// `~/Library/Sounds`. The sound name must be a filename without an extension, e.g. `Pop`.
     #[arg(long, env = "YKNOTIFY_DISMISSED_SOUND")]
     dismissed_sound: Option<String>,
+
+    /// Name of the macOS system sound to play when a FIDO2 touch request is dismissed.
+    ///
+    /// Overrides the `--dismissed-sound` option, which sets the dismissed sound for all types of
+    /// touch request.
+    #[arg(
+        long,
+        conflicts_with = "request_sound",
+        env = "YKNOTIFY_FIDO2_DISMISSED_SOUND"
+    )]
+    fido2_dismissed_sound: Option<String>,
+
+    /// Name of the macOS system sound to play when an OpenPGP touch request is dismissed.
+    ///
+    /// Overrides the `--dismissed-sound` option, which sets the dismissed sound for all types of
+    /// touch request.
+    #[arg(
+        long,
+        conflicts_with = "request_sound",
+        env = "YKNOTIFY_OPENPGP_DISMISSED_SOUND"
+    )]
+    openpgp_dismissed_sound: Option<String>,
 }
 
 #[derive(Deserialize)]
@@ -91,7 +135,11 @@ async fn main() -> Result<()> {
                     .summary("YubiKey Touch Needed")
                     .body("FIDO2 authentication is required.");
 
-                if let Some(sound) = args.request_sound.as_ref() {
+                if let Some(sound) = args
+                    .fido2_request_sound
+                    .as_ref()
+                    .or(args.request_sound.as_ref())
+                {
                     notification.sound_name(sound);
                 }
 
@@ -105,7 +153,11 @@ async fn main() -> Result<()> {
                     .summary("YubiKey Touch Confirmed")
                     .body("YubiKey touch was detected.");
 
-                if let Some(sound) = args.dismissed_sound.as_ref() {
+                if let Some(sound) = args
+                    .fido2_dismissed_sound
+                    .as_ref()
+                    .or(args.dismissed_sound.as_ref())
+                {
                     notification.sound_name(sound);
                 }
 
@@ -137,7 +189,11 @@ async fn main() -> Result<()> {
                     .summary("YubiKey Touch Needed")
                     .body("OpenPGP authentication is required.");
 
-                if let Some(sound) = args.request_sound.as_ref() {
+                if let Some(sound) = args
+                    .openpgp_request_sound
+                    .as_ref()
+                    .or(args.request_sound.as_ref())
+                {
                     notification.sound_name(sound);
                 }
 
@@ -155,7 +211,11 @@ async fn main() -> Result<()> {
                     .summary("YubiKey Touch Confirmed")
                     .body("YubiKey touch was detected.");
 
-                if let Some(sound) = args.dismissed_sound.as_ref() {
+                if let Some(sound) = args
+                    .openpgp_dismissed_sound
+                    .as_ref()
+                    .or(args.dismissed_sound.as_ref())
+                {
                     notification.sound_name(sound);
                 }
 


### PR DESCRIPTION
Here's one way we could do #3.

I've added additional CLI options (`--fido2-request-sound`, `--openpgp-request-sound`, `--fido2-dismissed-sound`, and `--openpgp-dismissed-sound`) that set the sound for a specific notification type. I've also updated the Nix module with the same options.

The more specific options are set to conflict with the more general ones - for example, you can't set `--request-sound` and `--fido2-request-sound` at the same time, you would have to pass `--fido2-request-sound` and `--openpgp-request-sound`.

This also lets you set a sound for one type (e.g. OpenPGP requests) but make another type be delivered silently (e.g. FIDO2 requests).

Closes #3.